### PR TITLE
custom ip address fact

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,5 +1,5 @@
 class sshd::base(
-  $ipaddress_fact = $sshd::ipaddress_fact,
+  $sshkey_ipaddress = $sshd::sshkey_ipaddress,
 ) {
 
   $sshd_config_content = $::lsbdistcodename ? {
@@ -29,10 +29,8 @@ class sshd::base(
       }
       # In case the node has uses a shared network address,
       # we don't define a sshkey resource using an IP address
-      $ipaddr = inline_template("<%= scope.lookupvar(ipaddress_fact) %>")
       if $sshd::shared_ip == 'no' {
-        @@sshkey{$ipaddr:
-
+        @@sshkey{$sshkey_ipaddress:
           ensure => present,
           tag    => 'ipaddress',
           type   => ssh-rsa,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class sshd(
   $print_motd = 'yes',
   $manage_shorewall = false,
   $shorewall_source = 'net',
-  $ipaddress_fact = 'ipaddress',
+  $sshkey_ipaddress = $::ipaddress
 ) {
 
   validate_bool($manage_shorewall)


### PR DESCRIPTION
Provide possibility to modify `ipaddress` fact which is used for ssh key. e.g. if you have interface

```
docker0   Link encap:Ethernet  HWaddr 42:e8:27:2b:28:8f  
          inet addr:172.17.42.1  Bcast:0.0.0.0  Mask:255.255.0.0
```

facter will assume that the public IP address is `172.17.42.1` which is a private IP and doesn't have to be unique in your network. So with this patch you can force using e.g. `ipaddress_eth0` fact. 

Is this OK? 

I wanted to write tests for this, but there are several out of scope variables being used which makes testing complicated. I will write a bigger pull request for changing structure of classes and then we can test it.
